### PR TITLE
Use protocol-relative URL for WebMIDIAPIShim/WebMIDIAPI

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
 
 	<script src="js/ui.js"></script>
 	<script src="js/main.js"></script>
-	<script src='http://cwilso.github.com/WebMIDIAPIShim/WebMIDIAPI.js'></script>
+	<script src='//cwilso.github.com/WebMIDIAPIShim/WebMIDIAPI.js'></script>
 	<script src="js/midi.js"></script>
 	<script src="js/vocoder.js"></script>
 	<script src="js/sliders.js"></script>


### PR DESCRIPTION
Nothing complicated. Currently the demo doesn't work with `https` since `WebMIDIAPIShim/WebMIDIAPI` is pulled in over `http`. Chrome (probably other browsers too) block this as an insecure resource. The protocol-relative URL will fix the problem, letting people that want to try the demo run it locally or using your demo site.